### PR TITLE
Scrolling+fasm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-RUN apt update && apt install -y wget grub-pc-bin xorriso build-essential \
+RUN apt update && apt install -y wget grub-pc-bin xorriso build-essential fasm \
     bison flex libgmp3-dev libmpc-dev libmpfr-dev texinfo
 
 WORKDIR /usr

--- a/docker-include/build.sh
+++ b/docker-include/build.sh
@@ -8,7 +8,7 @@ for file in src/*.c; do
     i686-elf-gcc -c "$file" -o "bin/$(basename -s .c $file).o" -std=gnu99 -ffreestanding -g -Wall -Wextra
 done
 
-i686-elf-as src/boot.s -o bin/boot.o
+fasm src/boot.s bin/boot.o
 i686-elf-gcc -T src/linker.ld -o build/paradise-os.bin -ffreestanding -nostdlib bin/*.o -lgcc
 
 if ! grub-file --is-x86-multiboot build/paradise-os.bin; then

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -4,33 +4,33 @@
 extern const u32 *multiboot_info;
 
 void kernel_main(void) {
-  usize width = multiboot_info[MB_FRAME_BUFFER_WIDTH_OFFSET];
-  usize height = multiboot_info[MB_FRAME_BUFFER_HEIGHT_OFFSET];
-  u16 *buffer = (u16 * ) multiboot_info[MB_FRAME_BUFFER_ADDR_OFFSET];
+    usize width = multiboot_info[MB_FRAME_BUFFER_WIDTH_OFFSET];
+    usize height = multiboot_info[MB_FRAME_BUFFER_HEIGHT_OFFSET];
+    u16 *buffer = (u16 * ) multiboot_info[MB_FRAME_BUFFER_ADDR_OFFSET];
 
-  terminal_init(width, height, buffer);
+    terminal_init(width, height, buffer);
 
-  terminal_write_string("Hello, Paradise!\n");
-  terminal_write_string("Multiboot flags: ");
-  terminal_print_hex(multiboot_info[MB_FLAGS_OFFSET]);
+    terminal_write_string("Hello, Paradise!\n");
+    terminal_write_string("Multiboot flags: ");
+    terminal_print_hex(multiboot_info[MB_FLAGS_OFFSET]);
 
-  terminal_write_string("\nCharset:\n");
-  terminal.color = vga_color_create(VGA_COLOR_LIGHT_BLUE, VGA_COLOR_BLACK);
-  for (int h = 0; h < 16; ++h) {
-      for (int l = 0; l < 16; ++l) {
-          terminal_putchar(h << 4 | l);
-      }
-      terminal_putchar('\n');
-  }
-  terminal.color = vga_color_create(VGA_COLOR_LIGHT_GREY, VGA_COLOR_BLACK);
+    terminal_write_string("\nCharset:\n");
+    terminal.color = vga_color_create(VGA_COLOR_LIGHT_BLUE, VGA_COLOR_BLACK);
+    for (int h = 0; h < 16; ++h) {
+        for (int l = 0; l < 16; ++l) {
+            terminal_putchar(h << 4 | l);
+        }
+        terminal_putchar('\n');
+    }
+    terminal.color = vga_color_create(VGA_COLOR_LIGHT_GREY, VGA_COLOR_BLACK);
 
-  terminal_write_string("Colors:\n");
-  for (int c = 0; c < 16; ++c) {
-      terminal.color = vga_color_create(VGA_COLOR_LIGHT_GREY, c);
-      terminal_putchar(' ');
-  }
+    terminal_write_string("Colors:\n");
+    for (int c = 0; c < 16; ++c) {
+        terminal.color = vga_color_create(VGA_COLOR_LIGHT_GREY, c);
+        terminal_putchar(' ');
+    }
 
-  for (;;) {
-    asm ("hlt");
-  }
+    for (;;) {
+        asm ("hlt");
+    }
 }

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -23,12 +23,21 @@ void terminal_init(usize width, usize height, u16 *buffer) {
     }
 }
 
+void terminal_scroll() {
+    for (usize r = 1; r < terminal.height; ++r) {
+        for (usize c = 0; c < terminal.width; ++c) {
+            terminal.buffer[(r - 1) * terminal.width + c] = terminal.buffer[r * terminal.width + c];
+        }
+    }
+}
+
 void terminal_putchar(u8 c) {
     if (c == '\n') {
         terminal.col = 0;
 
         if (++terminal.row == terminal.height) {
-            terminal.row = 0;
+            terminal.row--;
+            terminal_scroll();
         }
 
         return;


### PR DESCRIPTION
I added scrolling support to the terminal and migrated our assembler to [fasm](https://flatassembler.net/) (from gas). I found that gas has worse support for intel syntax and I generally prefer fasm. You will need to rebuild the compiler after this change.

