### PR TITLE
Timer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/src/drivers/timer/timer.c
+++ b/src/drivers/timer/timer.c
@@ -1,0 +1,29 @@
+#include "timer.h"
+#include "lib/types.h"
+#include "lib/util.h"
+#include "terminal/terminal.h" // Used for testing
+
+u64 ticks;
+const u32 freq = 100;
+
+void timer_handler() {
+    ++ticks;
+
+    #ifdef TESTS_ENABLED
+    if (ticks % 100 == 0) // Prints every second
+        terminal_printf("Timer ticked..\n");
+    #endif
+}
+
+void init_timer() {
+    ticks = 0;
+    irq_install_handler(0, &timer_handler);
+
+    // PIT oscillates 1.1931816666 Mhz
+    u32 divisor = 1193180 / freq;
+
+    // Use Square Wave Generator Mode : 0011 0110
+    outb(0x43, 0x36);
+    outb(0x40, (u8)(divisor & 0xFF));
+    outb(0x40, (u8)((divisor >> 8) & 0xFF));
+}

--- a/src/drivers/timer/timer.h
+++ b/src/drivers/timer/timer.h
@@ -1,0 +1,9 @@
+#ifndef TIMER_H_
+#define TIMER_H_
+
+#include "interrupts/interrupt.h"
+
+void timer_handler();
+void init_timer();
+
+#endif // TIMER_H_

--- a/src/interrupts/interrupt.h
+++ b/src/interrupts/interrupt.h
@@ -38,7 +38,7 @@ typedef struct {
     uint32_t cr2;
     uint32_t edi, esi, ebp, esp, ebx, edx, ecx, eax;
     uint32_t int_no, err_code;
-    uint32_t eip, csm, eflags, useresp, ss;
+    uint32_t eip, cs, eflags, useresp, ss;
 } InterruptRegisters;
 
 void init_idt();

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -7,6 +7,7 @@
 #include "memory/mem.h"
 #include "process/processes.h"
 #include "tests/testing.h"
+#include "drivers/timer/timer.h"
 #include "drivers/keyboard/keyboard.h"
 #include "drivers/serial/io.h"
 
@@ -61,6 +62,10 @@ void kernel_main(void) {
     map_pages(0x600000, 0x600000, 256); // identity map our kernel code and data
     enable_paging();
     terminal_printf("Enabled paging\n");
+
+    terminal_printf("Initializing Timer\n");
+    init_timer();
+    terminal_printf("Timer Initialized\n");
 
     terminal_printf("Initializing Keyboard\n");
     init_keyboard();


### PR DESCRIPTION
# Pull Request

## Description

Enabled and added functionality for IRQ0 with the Programmable Interrupt Timer (PIT). PIT gets initialized on start up and ticks 100 times per second or a rate of 100Hz.

## How Has This Been Tested?

The OS doesn't seem to crash while it runs. Adjusting the frequency doesn't seem to break anything either and other interrupts, external or system still work as expected.

## Checklist

- [x] My code follows the style guidelines of this project (Add the linter already joyal)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
