### PR TITLE
Register Timer Callback Syscall

### DIFF
--- a/src/drivers/timer/timer.c
+++ b/src/drivers/timer/timer.c
@@ -1,19 +1,43 @@
 #include "timer.h"
 #include "interrupts/interrupt.h"
+#include "lib/error.h"
 #include "lib/types.h"
 #include "lib/util.h"
+#include "syscall/syscall.h"
 #include "terminal/terminal.h"
 
-void (*timer_callback)(InterruptRegisters *regs) = NULL;
+static u64 system_ticks; // Total number of system ticks
+static u32 sched_ticks;  // Ticks between scheduler function call
+static u32 sched_tick_cur;
+
+void (*sched_callback)(InterruptRegisters *regs) = NULL;
 const u32 freq = 1000;
 
 void timer_handler(InterruptRegisters *regs) {
-    if (timer_callback)
-        timer_callback(regs);
+    if (sched_tick_cur == 0) {
+        sched_tick_cur = sched_ticks;
+        sched_callback(regs);
+    }
+    ++system_ticks;
+    --sched_tick_cur;
+}
+
+SyscallResult
+syscall_reg_tmr_cb(void(callback)(InterruptRegisters *regs), u32 ticks) {
+    if (ticks == 0)
+        SYSCALL_RETURN(0, 1);
+    sched_callback = callback;
+    sched_ticks = ticks;
+    SYSCALL_RETURN(0, 0);
 }
 
 void init_timer() {
     irq_install_handler(0, timer_handler);
+
+    system_ticks = 0;
+    sched_ticks = 10; // Default time until user override w/ syscall
+
+    register_syscall(5, syscall_reg_tmr_cb);
 
     // PIT oscillates 1.1931816666 Mhz
     u32 divisor = 1193180 / freq;

--- a/src/drivers/timer/timer.h
+++ b/src/drivers/timer/timer.h
@@ -2,8 +2,15 @@
 #define TIMER_H_
 
 #include "interrupts/interrupt.h"
+#include "lib/types.h"
+#include "syscall/syscall.h"
 
-extern void (*timer_callback)(InterruptRegisters *regs);
+extern void (*sched_callback)(InterruptRegisters *regs);
+
+// This function is here for testing until we have all the syscalls for user
+// mode schedulers.
+SyscallResult
+syscall_reg_tmr_cb(void(callback)(InterruptRegisters *regs), u32 ticks);
 
 void init_timer();
 

--- a/src/process/processes.c
+++ b/src/process/processes.c
@@ -220,7 +220,7 @@ SyscallResult syscall_read_message(char *out, u32 blocking) {
 }
 
 void processes_init() {
-    timer_callback = preempt;
+    syscall_reg_tmr_cb(preempt, 20 /*ms*/);
     pool_init(&process_pool);
     rb_init(&process_tree);
     queue_init(&run_queue);


### PR DESCRIPTION
# Pull Request

## Description

Register Timer Callback syscall implementation. Support for custom timers is now passed to the scheduler.

## How Has This Been Tested?

I tested with various callbacks and 2 processes. The OS seemed to swap between the 2 after the set amount of ticks.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
